### PR TITLE
Remove year from license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## MIT License
 
-Copyright (c) 2018 Uphold, Inc.
+Copyright (c) Uphold, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

Remove year from `LICENSE.md`.

After talking with @waldyrious, @fixe and @nunofgs I found that there is a lot a discussion around the dates in LICENSE files. 
Should we use a date? And what should be the format?

Given the possibilities we were discussing:
* Copyright (c) 2018 Uphold, Inc. (start of project)
* Copyright (c) 2019 Uphold, Inc. (current year)
* Copyright (c) 2018-2019 Uphold, Inc. (range)
* Copyright (c) Uphold, Inc. (no year)

We choose to go with the last one, with no year, mostly because we don't need to get back to the repo and change it every year avoiding that the repo goes to a closed source state without noticing that.