### PR TITLE
Fix test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,11 +7,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['22', '24']
+        node: ['20', '22', '24']
     name: Node ${{ matrix.node }}
 
     steps:
-    - uses: actions/checkout@v4
-    - run: yarn install --frozen-lockfile
-    - run: yarn lint
-    - run: yarn test
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Setup Node.js version
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node }}
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+
+    - name: Run lint
+      run: yarn lint
+
+    - name: Run tests
+      run: yarn test


### PR DESCRIPTION
## Description

- Update the GitHub Actions Test workflow by adding support for Node.js version 20, which is still in Maintenance, and actually setting up node version setup per workflow job.