### PR TITLE
Set input type of `validate()` to `unknown`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -185,7 +185,7 @@ type ConstraintMapping<T> =
   | Record<string, ConstraintValue | ConstraintValue[]>;
 
 /** Signature of `assert(data, constraints)` or `validate(data, constraints)`. */
-type ValidateFunction = <T>(data: T, constraints: ConstraintMapping<T> | Record<string, ConstraintValue>) => T;
+type ValidateFunction = <T>(data: unknown, constraints: ConstraintMapping<T> | Record<string, ConstraintValue>) => T;
 
 /** Custom Error type for `AssertionError`/`ValidationError`. */
 type ValidatorErrorType = new (...args: any[]) => Error;


### PR DESCRIPTION
## Description
Sets the input type of `validate()` to `unknown`.

Fixes errors caused by data being expected to be passed with the resolved typed, such as:

```ts
const rawUser: { name: string | undefined } = { name: 'foo' };
const user: { name: string } = validate<{ name: string }>(rawUser, { name: is.required() });
```

throwing
```
TS2345: Argument of type { name: string | undefined; } is not assignable to parameter of type { name: string; }
Types of property name are incompatible.
Type string | undefined is not assignable to type string
Type undefined is not assignable to type string
```
